### PR TITLE
Resolve flutter dependency conflicts

### DIFF
--- a/lib/presentation/create_listing/create_listing.dart
+++ b/lib/presentation/create_listing/create_listing.dart
@@ -7,7 +7,7 @@ import 'package:path/path.dart' as path;
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_google_places_hoc081098/flutter_google_places_hoc081098.dart';
-import 'package:flutter_google_places_hoc081098/google_maps_webservice_places.dart';
+import 'package:google_maps_webservice_ex/places.dart';
 import 'package:google_api_headers/google_api_headers.dart';
 
 class CreateListingScreen extends StatefulWidget {

--- a/lib/presentation/home_marketplace_feed/search_page.dart
+++ b/lib/presentation/home_marketplace_feed/search_page.dart
@@ -2,7 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:sizer/sizer.dart';
 import 'package:flutter_google_places_hoc081098/flutter_google_places_hoc081098.dart';
-import 'package:google_maps_webservice/places.dart';
+import 'package:google_maps_webservice_ex/places.dart';
 import 'package:geolocator/geolocator.dart';
 import './widgets/square_product_card.dart';
 import './widgets/shimmer_widgets.dart';

--- a/lib/presentation/home_marketplace_feed/widgets/location_autocomplete_field.dart
+++ b/lib/presentation/home_marketplace_feed/widgets/location_autocomplete_field.dart
@@ -1,7 +1,7 @@
 // File: widgets/location_autocomplete_field.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_google_places_hoc081098/flutter_google_places_hoc081098.dart';
-import 'package:flutter_google_places_hoc081098/google_maps_webservice_places.dart';
+import 'package:google_maps_webservice_ex/places.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:sizer/sizer.dart';
 import 'package:google_api_headers/google_api_headers.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   url_launcher: ^6.2.4
   
   # HTTP & Networking
-  http: ^0.13.0
+  http: ^1.2.1
   
   # Local Storage
   sqflite: ^2.3.2
@@ -89,7 +89,7 @@ dependencies:
   # Package Info
   package_info_plus: ^8.3.0
   geocoding: ^2.1.0
-  google_maps_webservice: ^0.0.20-nullsafety.5
+  google_maps_webservice_ex: ^0.0.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Upgrade `http` package and replace `google_maps_webservice` with `google_maps_webservice_ex` to resolve dependency conflicts.

The original `google_maps_webservice` package is unmaintained and incompatible with the `http` package version required by `flutter_google_places_hoc081098`. Switching to `google_maps_webservice_ex` allows for the necessary `http` upgrade.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-c48306a4-41b5-42ee-8e4e-8577bf391fb8) · [Cursor](https://cursor.com/background-agent?bcId=bc-c48306a4-41b5-42ee-8e4e-8577bf391fb8)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)